### PR TITLE
chore: update actions/cache to v4

### DIFF
--- a/.github/workflows/mikeals-workflow.yml
+++ b/.github/workflows/mikeals-workflow.yml
@@ -15,7 +15,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - name: Cache node_modules
       id: cache-modules
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       with:
         path: node_modules
         key: ${{ matrix.node-version }}-${{ runner.OS }}-build-${{ hashFiles('package.json') }}
@@ -33,7 +33,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Cache node_modules
       id: cache-modules
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       with:
         path: node_modules
         key: 12.x-${{ runner.OS }}-build-${{ hashFiles('package.json') }}


### PR DESCRIPTION
actions/cache v1 and v2 are getting deprecated on Ferbuary 1st.